### PR TITLE
added missing fields in the webhook resource data response

### DIFF
--- a/lib/src/models/webhook_resource_data_response.dart
+++ b/lib/src/models/webhook_resource_data_response.dart
@@ -317,6 +317,8 @@ class Fields extends Equatable {
     this.curp,
     this.ne,
     this.ocrNumber,
+    this.surname,
+    this.lastName,
   });
 
   factory Fields.fromMap(Map<dynamic, dynamic> json) {
@@ -337,6 +339,8 @@ class Fields extends Equatable {
       curp: parseField('curp'),
       ne: parseField('ne'),
       ocrNumber: parseField('ocrNumber'),
+      surname: parseField('surname'),
+      lastName: parseField('lastName'),
     );
   }
 
@@ -349,6 +353,8 @@ class Fields extends Equatable {
   final DocumentField? curp;
   final DocumentField? ne;
   final DocumentField? ocrNumber;
+  final DocumentField? surname;
+  final DocumentField? lastName;
 
   @override
   List<Object?> get props {
@@ -362,6 +368,8 @@ class Fields extends Equatable {
       curp,
       ne,
       ocrNumber,
+      surname,
+      lastName,
     ];
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  In the webhook response, some data was missing.

  There you can see the official documentation:
  https://docs.metamap.com/reference/retrieve-webhook-resource-data-1
  On the dashboard, you can see the json of the response https://api.getmati.com/v2/verifications/{id} and you will see that has more data than the documentation

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status: [READY / NOT READY]

READY

## Description

It was added to the MatiWebhookResourceData model, in this way you can get both the first and last names.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
