### PR TITLE
fixed error in fields on the response of the webhook

### DIFF
--- a/lib/src/models/webhook_resource_data_response.dart
+++ b/lib/src/models/webhook_resource_data_response.dart
@@ -318,7 +318,7 @@ class Fields extends Equatable {
     this.ne,
     this.ocrNumber,
     this.surname,
-    this.lastName,
+    this.firstName,
   });
 
   factory Fields.fromMap(Map<dynamic, dynamic> json) {
@@ -340,7 +340,7 @@ class Fields extends Equatable {
       ne: parseField('ne'),
       ocrNumber: parseField('ocrNumber'),
       surname: parseField('surname'),
-      lastName: parseField('lastName'),
+      firstName: parseField('firstName'),
     );
   }
 
@@ -354,7 +354,7 @@ class Fields extends Equatable {
   final DocumentField? ne;
   final DocumentField? ocrNumber;
   final DocumentField? surname;
-  final DocumentField? lastName;
+  final DocumentField? firstName;
 
   @override
   List<Object?> get props {
@@ -369,7 +369,7 @@ class Fields extends Equatable {
       ne,
       ocrNumber,
       surname,
-      lastName,
+      firstName,
     ];
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

It was change the naming of one field on the response of the webhook verification.

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status: [READY / NOT READY]

<!-- Indicate if this PR is ready for review or if it needs work before merging. -->

## Description

Just one naming change on the class Fields part of the class MatiWebhookResourceData.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
